### PR TITLE
A fake version of an Angular dendrogram factory

### DIFF
--- a/public/app/dendrogram/dendrogram.controller.js
+++ b/public/app/dendrogram/dendrogram.controller.js
@@ -1,13 +1,15 @@
 (function() {
   angular.module('app')
-  .controller('DendrogramController', DendrogramController)
+  .controller('DendrogramController', [DendrogramController])
 
-  function DendrogramController() {
-    var vm = this
-    
+  DendrogramController.$inject = ['dendrogramService']
+
+  function DendrogramController(dendrogramService) {
+    // var vm = this
+    console.log(dendrogramService)
     // Maybe do an $http to retrieve json data here,
     // instead of using D3.json. Not sure which is best.
     // Right now, .data is not doing anything, obvs.
-    vm.data = 'whatever'
+    // vm.data = 'whatever'
   }
 })()

--- a/public/app/dendrogram/dendrogram.directive.js
+++ b/public/app/dendrogram/dendrogram.directive.js
@@ -1,8 +1,10 @@
 (function() {
   angular.module('app')
-  .directive('dendrogram', dendrogram)
+  .directive('dendrogram', [dendrogram])
+
   var w = 300
   var h = 300
+
   function dendrogram() {
     return {
       restrict: 'E',
@@ -20,14 +22,7 @@
 
   function drawTreeOfLife($scope, $element, $attr) {
     /***** Initialization ****/
-
-    // Set up the svg container for the visualization named 'viz'
-    var viz = d3.select($element[0])
-      .append('svg')
-      .attr('width', 800)
-      .attr('height', 800)
-      .append('svg:g')
-      .attr('transform', 'translate(40, 0)')
+    var viz = dendrogramService.initialize($element)
 
     // The info that pops up on hover
     var tooltip = d3.select("body").append("div")

--- a/public/app/dendrogram/dendrogram.factory.js
+++ b/public/app/dendrogram/dendrogram.factory.js
@@ -1,0 +1,20 @@
+// This "factory" puts some useful dendrogram-related functions
+// into the global space under the object 'dendrogramService'
+// I know this is bad!
+// This is meant to mock up an Angular factory until I can figure out
+// how to get the real deal wired up.
+
+var dendrogramService = {
+  initialize: initializeSvg
+}
+
+/*** Implementation ***/
+function initializeSvg(element) {
+  // Set up the svg container for the visualization
+  return d3.select(element[0])
+  .append('svg')
+  .attr('width', 800)
+  .attr('height', 800)
+  .append('svg:g')
+  .attr('transform', 'translate(40, 0)')
+}

--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,7 @@
     <script src="/bower_components/angular/angular.js"></script>
     <script src="/bower_components/d3/d3.js"></script>
     <script src="/app/app.module.js"></script>
+    <script src="/app/dendrogram/dendrogram.factory.js"></script>
     <script src="/app/dendrogram/dendrogram.controller.js"></script>
     <script src="/app/dendrogram/dendrogram.directive.js"></script>
   </body>


### PR DESCRIPTION
A fake version of an Angular factory for handling dendrogram initialization, scary math, etc. The idea is to abstract away the nitty-gritty, leaving the directive itself clear and readable.

Why didn't I use a proper Angular factory? I tried, but I couldn't figure it out. For some reason the factory was returning only the 'data' on the controller's $scope. Super weird. Will have to come back and do it the right way later.